### PR TITLE
chore: use correct module export on tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
         "skipLibCheck": true,
         "sourceMap": true,
         "strict": true,
-        "moduleResolution": "bundler",
         "rootDirs": [
             ".",
             "./.svelte-kit/types",


### PR DESCRIPTION
No da errores al dejar el `moduleResolution` por defecto del tsconfig en `.svelte-kit` (borrando la línea).

Aquí una captura de vscode al probar un import en `index.ts`.

<img width="1400" height="993" alt="image" src="https://github.com/user-attachments/assets/4d999f3e-b42f-42fd-a992-ddf6d30c4044" />

Sin embargo, me da la sesación de que esto ya lo hemos probado antes, ¿no? No tengo login en vscode así que las settings deberían ser lo más estándar. 

Si sigue fallándote, revisa el `settings.json` global de vscode, ¿Puede ser que al hacer login e importarlo el settings global de otro lado se rompa? Busca el `> Preferences: Open User Settings (JSON)` En mi máquina sale (secciones relevantes):

```json
    "svelte.enable-ts-plugin": true,
```